### PR TITLE
GNOME - Disable filesystem permissions

### DIFF
--- a/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
+++ b/NickvisionTubeConverter.GNOME/Controls/DownloadRow.cs
@@ -34,6 +34,9 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
     [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
     private static partial void gtk_file_launcher_launch(nint fileLauncher, nint parent, nint cancellable, GAsyncReadyCallback callback, nint data);
 
+    [LibraryImport("libadwaita-1.so.0", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial void gtk_file_launcher_open_containing_folder(nint fileLauncher, nint parent, nint cancellable, GAsyncReadyCallback callback, nint data);
+
     private readonly Localizer _localizer;
     private readonly Download _download;
     private readonly GSourceFunc _runStartCallback;
@@ -129,9 +132,9 @@ public partial class DownloadRow : Adw.Bin, IDownloadRowControl
         };
         _openFolderButton.OnClicked += (sender, e) =>
         {
-            var file = Gio.FileHelper.NewForPath(_download.SaveFolder);
+            var file = Gio.FileHelper.NewForPath($"{_download.SaveFolder}{Path.DirectorySeparatorChar}{_download.Filename}");
             var fileLauncher = gtk_file_launcher_new(file.Handle);
-            gtk_file_launcher_launch(fileLauncher, 0, 0, (source, res, data) => { }, 0);
+            gtk_file_launcher_open_containing_folder(fileLauncher, 0, 0, (source, res, data) => { }, 0);
         };
         _retryButton.OnClicked += async (sender, e) => await RetryAsync();
         _btnLogToClipboard.OnClicked += (sender, e) =>

--- a/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.json
+++ b/NickvisionTubeConverter.GNOME/org.nickvision.tubeconverter.json
@@ -22,10 +22,7 @@
         "--device=dri",
         "--share=ipc",
         "--share=network",
-        "--talk-name=com.canonical.Unity",
-        "--filesystem=xdg-videos",
-        "--filesystem=xdg-music",
-        "--filesystem=xdg-download"
+        "--talk-name=com.canonical.Unity"
     ],
     "cleanup": [
       "/include",


### PR DESCRIPTION
This PR removes permissions for user folders and adds handling of inaccessible paths for save folder. `gtk_file_launcher_open_containing_folder` doesn't open real path, but I think it's the best we can use, because the file will be selected in file manager and also, from my experience, portal folders are like mirrors of real folders, moving files from there to another place affects real folder too, so the only issue is confusing path in file manager.