### PR TITLE
GNOME - Add pulsing bar for processing

### DIFF
--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -116,6 +116,13 @@ Adw.Bin _root {
       }
 
       Adw.ViewStackPage {
+        name: "processing";
+        child: Gtk.ProgressBar _pulsingBar {
+          hexpand: true;
+        };
+      }
+
+      Adw.ViewStackPage {
         name: "done";
         child: Gtk.LevelBar _levelBar {
           hexpand: true;


### PR DESCRIPTION
@nlogozzo The solution that you suggested with while loop doesn't work well because the bar shouldn't pulse every frame. I think that using a separate bar is the most reliable solution.