### PR TITLE
Shared - Fix aria min split size

### DIFF
--- a/NickvisionTubeConverter.Shared/Models/Download.cs
+++ b/NickvisionTubeConverter.Shared/Models/Download.cs
@@ -217,7 +217,7 @@ public class Download
                     ariaParams.Append(new PyString("--show-console-readout=false"));
                     ariaParams.Append(new PyString($"--stop-with-process={_ariaKeeper.Id}"));
                     ariaParams.Append(new PyString($"--max-connection-per-server={options.AriaMaxConnectionsPerServer}"));
-                    ariaParams.Append(new PyString($"--min-split-size={options.AriaMinSplitSize}"));
+                    ariaParams.Append(new PyString($"--min-split-size={options.AriaMinSplitSize}M"));
                     ariaDict["default"] = ariaParams;
                     _ytOpt.Add("external_downloader_args", ariaDict);
                 }


### PR DESCRIPTION
Aria wasn't working, raising the following error (thanks @soumyaDghosh for finding this):

```
[youtube] Extracting URL: https://www.youtube.com/watch?v=VF_FcxtnqS0
[youtube] VF_FcxtnqS0: Downloading webpage
[youtube] VF_FcxtnqS0: Downloading android player API JSON
[info] VF_FcxtnqS0: Downloading 1 format(s): 251
Deleting existing file /home/soumyaxubuntu/snap/tube-converter/89/.config/Nickvision/Nickvision Tube Converter/temp/3d49de30-f046-4d7f-96bc-19962365496c/3d49de30-f046-4d7f-96bc-19962365496c.webp
[info] Downloading video thumbnail 41 ...
[info] Writing video thumbnail 41 to: /home/soumyaxubuntu/snap/tube-converter/89/.config/Nickvision/Nickvision Tube Converter/temp/3d49de30-f046-4d7f-96bc-19962365496c/3d49de30-f046-4d7f-96bc-19962365496c.webp
[dashsegments] Total fragments: 1
[dashsegments] Fragment downloads will be delegated to aria2c
[download] Destination: /home/soumyaxubuntu/snap/tube-converter/89/.config/Nickvision/Nickvision Tube Converter/temp/3d49de30-f046-4d7f-96bc-19962365496c/3d49de30-f046-4d7f-96bc-19962365496c.webm
Exception: [[AbstractOptionHandler.cc:69](http://abstractoptionhandler.cc:69/)] errorCode=28 We encountered a problem while processing the option '--min-split-size'.
  -> [[OptionHandlerImpl.cc:184](http://optionhandlerimpl.cc:184/)] errorCode=1 min-split-size must be between 1048576 and 1073741824.
Usage:
 -k, --min-split-size=SIZE    aria2 does not split less than 2*SIZE byte range.
                              For example, let's consider downloading 20MiB
                              file. If SIZE is 10M, aria2 can split file into 2
                              range [0-10MiB) and [10MiB-20MiB) and download it
                              using 2 sources(if --split >= 2, of course).
                              If SIZE is 15M, since 2*15M > 20MiB, aria2 does
                              not split file and download it using 1 source.
                              You can append K or M(1K = 1024, 1M = 1024K).

                              Possible Values: 1048576-1073741824
                              Default: 20M
                              Tags: #basic, #http, #ftp

ERROR: Unable to open fragment 0; [Errno 2] No such file or directory: '/home/soumyaxubuntu/snap/tube-converter/89/.config/Nickvision/Nickvision Tube Converter/temp/3d49de30-f046-4d7f-96bc-19962365496c/3d49de30-f046-4d7f-96bc-19962365496c.webm.part-Frag0'


ERROR: aria2c exited with code -1
```

One char fixes it 😄 