### PR TITLE
spelling.yml: update actions/checkout to v3, fix Node 12 deprecation warning

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -9,7 +9,7 @@ jobs:
   codespell:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: codespell-project/actions-codespell@master
         with:
           check_filenames: true


### PR DESCRIPTION
## Changes

- spelling.yml: bump `actions/checkout` from `v2` (Node 12) to `v3` (Node 16), fix Node 12 deprecation warning in [action runs](https://github.com/NickvisionApps/TubeConverter/actions/workflows/spelling.yml).