### PR TITLE
GNOME Circle

### DIFF
--- a/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
+++ b/NickvisionTubeConverter.GNOME/Blueprints/download_row.blp
@@ -4,13 +4,12 @@ using Adw 1;
 Adw.Bin _root {
   Gtk.Box {
     orientation: vertical;
-    margin-start: 6;
-    margin-top: 6;
-    margin-end: 6;
-    margin-bottom: 6;
 
     Gtk.Box {
       orientation: horizontal;
+      margin-start: 6;
+      margin-top: 6;
+      margin-end: 6;
       spacing: 6;
 
       Gtk.Image _statusIcon {
@@ -108,8 +107,8 @@ Adw.Bin _root {
     }
 
     Adw.ViewStack _stateViewStack {
-      margin-start: 10;
-      margin-end: 10;
+      margin-start: 16;
+      margin-end: 16;
       margin-bottom: 8;
 
       Adw.ViewStackPage {
@@ -147,13 +146,15 @@ Adw.Bin _root {
         vexpand: true;
         halign: end;
         valign: end;
-        margin-bottom: 8;
-        margin-end: 14;
+        margin-bottom: 14;
+        margin-end: 20;
 
         styles ["opaque"]
       }
 
       Gtk.ScrolledWindow _scrollLog {
+        margin-start: 6;
+        margin-end: 6;
         height-request: 100;
         child: Gtk.Label _lblLog {
           margin-start: 6;


### PR DESCRIPTION
https://gitlab.gnome.org/Teams/Circle/-/issues/128#note_1758431

- [ ] The summary "Get video and audio from the web" could be shorter/catchier. How about something like "Download web videos"?
- [x] The terminal output should be cut off at the bottom edge of the card, rather than 5px above it
 - [x] The divider line between the top part of the card and the terminal output should go edge to edge, spanning the entire width of the card